### PR TITLE
Feature/1691 send the fillr js npm library electronjs

### DIFF
--- a/electronjs/fillr.js
+++ b/electronjs/fillr.js
@@ -1,0 +1,18 @@
+const FillrController = require('fillr-extension/fillr-controller');
+const { ProfileDataInterface } = FillrController;
+
+const ProfileData = {
+  "ContactDetails.Emails.Email.Address":"jamesw999@gmail.com",
+  "PersonalDetails.FirstName":"John",
+  "PersonalDetails.LastName":"Wick",
+}
+
+const devKey = '';  // Set your dev key
+const secretKey = ''; // Set your secret key
+const profileDataHandler = new ProfileDataInterface((mappings) => {
+  mappings.profile = ProfileData; // Set your profile data
+  fillr.performFill(mappings);
+  console.log(fillr.getApiState().toString()) // Check api state
+})
+
+const fillr = new FillrController.default(devKey, secretKey, profileDataHandler);

--- a/electronjs/main.js
+++ b/electronjs/main.js
@@ -1,0 +1,37 @@
+const {app, BrowserWindow, session} = require('electron')
+const path = require('path');
+const fs = require('fs');
+
+let mainWindow
+
+function createWindow () {
+  mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true,
+      webSecurity: false
+    }
+  })
+
+  mainWindow.loadURL('https://www.fillr.com/demo')
+
+  mainWindow.on('closed', function () {
+    mainWindow = null
+  })
+
+  mainWindow.webContents.once('did-navigate', () => {
+    const widgetString = fs.readFileSync(path.join(__dirname, 'fillr.js'), "utf8");
+    mainWindow.webContents.executeJavaScript(widgetString)
+  });
+}
+
+app.on('ready', createWindow)
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit()
+})
+
+app.on('activate', function () {
+  if (mainWindow === null) createWindow()
+})

--- a/electronjs/package.json
+++ b/electronjs/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "electron-fillr-integration",
+  "version": "0.1.0",
+  "description": "A minimal Electron fillr application",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Fillr/browser-example-integration.git"
+  },
+  "keywords": [
+    "electron-fillr-integration"
+  ],
+  "author": "Fillr",
+  "license": "ISC",
+  "devDependencies": {
+    "electron": "^5.0.0"
+  },
+  "dependencies": {
+    "fillr-extension": "^0.1.1"
+  }
+}

--- a/electronjs/readme.md
+++ b/electronjs/readme.md
@@ -1,0 +1,52 @@
+# Electron Example Integration
+
+## Building
+
+### Pre-requisites
+
+- Set dev key, secret key, profile listener and profile data on fillr.js
+
+### Installation
+
+```bash
+$> npm install fillr-extension --registry https://api.bintray.com/npm/fillr/npm
+$> npm install
+```
+
+### Run
+
+```bash
+$> npm start
+```
+
+### Usage
+
+- Configure dev key and secret key
+- Implement profile listener
+- Declare user profile data
+
+```javascript
+const FillrController = require('fillr-extension/fillr-controller');
+const { ProfileDataInterface } = FillrController;
+
+const ProfileData = {
+  "ContactDetails.Emails.Email.Address":"jamesw999@gmail.com",
+  "PersonalDetails.FirstName":"John",
+  "PersonalDetails.LastName":"Wick",
+}
+
+const devKey = '';  // Set your dev key
+const secretKey = ''; // Set your secret key
+const profileDataHandler = new ProfileDataInterface((mappings) => {
+  mappings.profile = ProfileData; // Set your profile data
+  fillr.performFill(mappings);
+  console.log(fillr.getApiState().toString()) // Check api state
+})
+
+const fillr = new FillrController.default(devKey, secretKey, profileDataHandler);
+```
+
+See the sample code for more details.
+
+### Error
+Check this [url](https://github.com/Fillr/browser-example-integration#error)


### PR DESCRIPTION
## Overview

This PR adds new integration for [Electron app](https://electronjs.org/)

- add sample electron app
- integrate with fillr on electron app
- add readme

Please set devKey, secretKey before you test it. Please read [readme.md](https://github.com/Fillr/browser-example-integration/tree/feature/1691-send-the-fillr-js-npm-library-electronjs/electronjs) for more details