### PR TITLE
add sample electron integration on webview

### DIFF
--- a/electronjs/index.html
+++ b/electronjs/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Electron Example Integration</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+        webview {
+            width: 100%;
+            height: 1000px;
+        }
+    </style>
+  </head>
+  <body>
+    <webview src="https://www.google.com/" preload="./fillr.js" autosize nodeIntegrationInSubFrames allowRunningInsecureContent disablewebsecurity></webview>
+  </body>
+  <script src="webview.js"></script>
+</html>

--- a/electronjs/main.js
+++ b/electronjs/main.js
@@ -8,16 +8,22 @@ function createWindow () {
     width: 1500,
     height: 1000,
     webPreferences: {
+      // We highly recommend the integration with `BrowserView` instead of `webview` because of the following issues
+      // https://github.com/electron/electron/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+webview
+      // `BrowserView`is meant to be an alternative to the webview tag
+      webviewTag: true,
       nodeIntegration: false,
       nodeIntegrationInSubFrames: true,
-      preload: path.join(__dirname, 'fillr.js'),
+      // This is only for using `BrowserWindow` instead of webview
+      // preload: path.join(__dirname, 'fillr.js'),
       contextIsolation: false,
       webSecurity: false,
       allowRunningInsecureContent: true,
     }
   })
-
-  mainWindow.loadURL('https://www.google.com')
+  
+  // mainWindow.loadURL('https://www.google.com')
+  mainWindow.loadURL(`file://${__dirname}/index.html`)
 
   mainWindow.on('closed', function () {
     mainWindow = null

--- a/electronjs/package.json
+++ b/electronjs/package.json
@@ -17,11 +17,11 @@
   "author": "Fillr",
   "license": "ISC",
   "devDependencies": {
-    "electron": "^5.0.0",
+    "electron": "^5.0.4",
     "electron-builder": "^20.40.2"
   },
   "dependencies": {
-    "fillr-extension": "^0.1.2"
+    "fillr-extension": "^0.1.3"
   },
   "build": {
     "productName": "Fillr Electron",

--- a/electronjs/package.json
+++ b/electronjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-fillr-integration",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A minimal Electron fillr application",
   "main": "main.js",
   "scripts": {

--- a/electronjs/webview.js
+++ b/electronjs/webview.js
@@ -1,0 +1,6 @@
+const webview = document.querySelector('webview')
+
+webview.addEventListener('dom-ready', () => {
+  webview.openDevTools()
+})
+


### PR DESCRIPTION
## Overview
This PR changes the way of the electron integration with `webview` tag instead of `browserWindow`

- add `webview` tag on `webPreferences`
- add a `index.html` with `webview` tag
- add a script to turn on dev tool

## Version
0.1.2
