### PR TITLE
Chore/update readme for npm library

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -44,5 +44,5 @@
     "icon.png",
     "popup.html"
   ],
-  "content_security_policy": "script-src 'self' object-src 'self'"
+  "content_security_policy": "script-src 'self' https://api.fillr.com/; object-src 'self'"
 }

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ rm -rf dist
 
 npm install ts-loader tslint tslint-loader typescript typings uglifyjs-webpack-plugin webpack --save-dev
 
-npm install fillr-extension --registry https://api.bintray.com/npm/fillr/npm
+npm i @fillr_letspop/desktop-autofill
 
 webpack
 

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ rm -rf dist
 npm install ts-loader tslint tslint-loader typescript typings uglifyjs-webpack-plugin webpack --save-dev
 
 npm i @fillr_letspop/desktop-autofill
+npm i @fillr_letspop/cart-scraper
 
 webpack
 

--- a/electronjs/fillr.js
+++ b/electronjs/fillr.js
@@ -19,13 +19,13 @@ const interval = setInterval(() => {
     const fillr = new FillrController.default(devKey, secretKey, profileDataHandler);
 
     const FillrScraper = require('@fillr_letspop/cart-scraper')
-    window.FillrCartInformationExtractionInterface.setDevKey(devKey);
+    FillrScraper.setDevKey(devKey);
     const onCartDetected = function(ev) {
 
       const cartInfo = ev.detail;
       // Do something with cartInfo. See the example cart information json on readme
     }
     document.addEventListener('fillr:cart:detected', onCartDetected);
-    window.FillrCartInformationExtractionInterface.start();
+    FillrScraper.start();
   }
 }, 1000);

--- a/electronjs/package.json
+++ b/electronjs/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@fillr_letspop/desktop-autofill": "^0.1.4",
-    "@fillr_letspop/cart-scraper": "^1.3.37"
+    "@fillr_letspop/cart-scraper": "^1.3.42"
   },
   "build": {
     "productName": "Fillr Electron",

--- a/electronjs/readme.md
+++ b/electronjs/readme.md
@@ -57,10 +57,10 @@ See the sample code for more details.
 const FillrScraper = require('@fillr_letspop/cart-scraper')
 ```
 
-- Set dev key before calling `FillrCartInformationExtractionInterface.start()`
+- Set dev key before calling `FillrScraper.start()`
 
 ```javascript
-window.FillrCartInformationExtractionInterface.setDevKey('YOUR_OWN_DEV_KEY');
+FillrScraper.setDevKey('YOUR_OWN_DEV_KEY');
 ```
 
 - Define the event listener `onCartDetected()`
@@ -74,7 +74,7 @@ document.addEventListener('fillr:cart:detected', onCartDetected);
 
 - start the cart information extraction
 ```javascript
-window.FillrCartInformationExtractionInterface.start(); 
+FillrScraper.start(); 
 ```
 
 ### Example Cart Information JSON

--- a/electronjs/readme.md
+++ b/electronjs/readme.md
@@ -77,7 +77,7 @@ document.addEventListener('fillr:cart:detected', onCartDetected);
 window.FillrCartInformationExtractionInterface.start(); 
 ```
 
-### Exampe Cart Information JSON
+### Example Cart Information JSON
 
 ```json
 {

--- a/electronjs/readme.md
+++ b/electronjs/readme.md
@@ -63,7 +63,7 @@ const FillrScraper = require('@fillr_letspop/cart-scraper')
 window.FillrCartInformationExtractionInterface.setDevKey('YOUR_OWN_DEV_KEY');
 ```
 
-- Define the event listener `onCartDetected()` 
+- Define the event listener `onCartDetected()`
 ```javascript
 const onCartDetected = function(ev) {
   const cartInfo = ev.detail;

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import FillrController, { ProfileDataInterface } from 'fillr-extension/fillr-controller';
+import FillrController, { ProfileDataInterface } from '@fillr_letspop/desktop-autofill';
 import profileData from './profile-data-en-us'; // see full profile example data
 
 // Setting custom profile data

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import FillrController, { ProfileDataInterface } from '@fillr_letspop/desktop-autofill';
 import profileData from './profile-data-en-us'; // see full profile example data
+import * as FillrScraper from '@fillr_letspop/cart-scraper';
 
 // Setting custom profile data
 // const profileData = {
@@ -17,3 +18,11 @@ const profileDataHandler = new ProfileDataInterface((mappings) => {
 })
 
 const fillr = new FillrController(devKey, secretKey, profileDataHandler);
+
+FillrScraper.setDevKey(devKey);
+const onCartDetected = function(ev) {
+  // const cartInfo = ev.detail;
+  // Do something with cartInfo. See the example cart information json on readme
+}
+document.addEventListener('fillr:cart:detected', onCartDetected);
+FillrScraper.start();

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "author": "Fillr",
   "license": "Copyright Pop Tech",
   "dependencies": {
-    "@fillr_letspop/desktop-autofill": "^0.1.4",
-    "@fillr_letspop/cart-scraper": "^1.3.37"
+    "@fillr_letspop/cart-scraper": "^1.3.37",
+    "@fillr_letspop/desktop-autofill": "^0.1.4"
   },
   "devDependencies": {
     "ts-loader": "^2.3.7",
-    "tslint": "^5.16.0",
+    "tslint": "^5.18.0",
     "tslint-loader": "^3.6.0",
     "typescript": "^2.9.2",
     "typings": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Fillr",
   "license": "Copyright Pop Tech",
   "dependencies": {
-    "@fillr_letspop/cart-scraper": "^1.3.37",
+    "@fillr_letspop/cart-scraper": "^1.3.42",
     "@fillr_letspop/desktop-autofill": "^0.1.4"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,8 @@
 
 ### Installation
 
+- To download `@fillr_letspop/cart-scraper` for the private package, you need to get permissions added to npmjs. Please contact product@fillr.com
+
 ```bash
 $> npm i @fillr_letspop/desktop-autofill
 $> npm i @fillr_letspop/cart-scraper

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ document.addEventListener('fillr:cart:detected', onCartDetected);
 window.FillrCartInformationExtractionInterface.start(); 
 ```
 
-### Exampe Cart Information JSON
+### Example Cart Information JSON
 
 ```json
 {
@@ -98,7 +98,7 @@ The `cart_total` value type of cart information represents as the number to avoi
 
 See the sample extension under `dist/chrome` after running build script. You can check the basic functionality of `fillr-extension` library on sample extension. After `load upacked`, all the page which has the form will be filled automatically.
 
-When you make your own extension, you should configure the following things on `manifest.json`. `all_frames` should be `true` and `js` includes the files which imports `fillr-extension/fillr-controller`. This will enable all the iframe which has form to be filled.
+When you make your own extension, you should configure the following things on `manifest.json`. `all_frames` should be `true` and `js` includes the files which imports `@fillr_letspop/desktop-autofill`. This will enable all the iframe which has form to be filled.
 
 ```
   "content_scripts": [

--- a/readme.md
+++ b/readme.md
@@ -59,10 +59,10 @@ See the sample code for more details.
 const FillrScraper = require('@fillr_letspop/cart-scraper')
 ```
 
-- Set dev key before calling `FillrCartInformationExtractionInterface.start()`
+- Set dev key before calling `FillrScraper.start()`
 
 ```javascript
-window.FillrCartInformationExtractionInterface.setDevKey('YOUR_OWN_DEV_KEY');
+FillrScraper.setDevKey('YOUR_OWN_DEV_KEY');
 ```
 
 - Define the event listener `onCartDetected()` 
@@ -76,7 +76,7 @@ document.addEventListener('fillr:cart:detected', onCartDetected);
 
 - start the cart information extraction
 ```javascript
-window.FillrCartInformationExtractionInterface.start(); 
+FillrScraper.start(); 
 ```
 
 ### Example Cart Information JSON


### PR DESCRIPTION
## Overview

This PR updates latest cart scraper integration with 1.3.42

- Fix chrome extension CSP's error
- Update readme for cart scraper on Chrome extension
- Use exports module on cart scraper integration