### PR TITLE
Bugfix/2002 fix autofill issues

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2015-present Pop Tech Pty Ltd.
+
+The Fillr Product is copyrighted and protected by the laws of Australia, 
+the United States, and many other countries, and by international treaty 
+provisions. 
+You may not remove or alter any trademark, logo, copyright or other 
+proprietary notices, legends, symbols or labels in the Fillr Product. 
+Except as otherwise expressly agreed in writing by you and Pop Tech, 
+Pop Tech grants no express or implied right under Pop Tech's patents, 
+copyrights, trademarks, or other intellectual property rights. 
+You agree to prevent any unauthorized use of the Fillr Product.
+You acknowledge that any unauthorized reproduction by you of any proprietary 
+information or other intellectual property in, or provided or available via, 
+a Fillr Product or any portion of it may result in legal action being taken 
+against you.
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -3,7 +3,7 @@
   "name": "Fillr's sample extension",
   "short_name": "Fillr's sample extension",
   "description": "Fillr's sample extensions using library",
-  "version": "0.1.0",
+  "version": "0.1.8",
   "background": {
     "scripts": [
       "sample-index-bundled.js"
@@ -27,6 +27,7 @@
         "http://*/*",
         "https://*/*"
       ],
+      "match_about_blank": true,
       "all_frames": true,
       "js": [
         "sample-index-bundled.js"

--- a/electronjs/main.js
+++ b/electronjs/main.js
@@ -11,19 +11,19 @@ function createWindow () {
       // We highly recommend the integration with `BrowserView` instead of `webview` because of the following issues
       // https://github.com/electron/electron/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+webview
       // `BrowserView`is meant to be an alternative to the webview tag
-      webviewTag: true,
+      // webviewTag: true,
       nodeIntegration: false,
       nodeIntegrationInSubFrames: true,
       // This is only for using `BrowserWindow` instead of webview
-      // preload: path.join(__dirname, 'fillr.js'),
+      preload: path.join(__dirname, 'fillr.js'),
       contextIsolation: false,
       webSecurity: false,
       allowRunningInsecureContent: true,
     }
   })
   
-  // mainWindow.loadURL('https://www.google.com')
-  mainWindow.loadURL(`file://${__dirname}/index.html`)
+  mainWindow.loadURL('https://www.google.com')
+  // mainWindow.loadURL(`file://${__dirname}/index.html`)
 
   mainWindow.on('closed', function () {
     mainWindow = null

--- a/electronjs/package.json
+++ b/electronjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-fillr-integration",
-  "version": "0.1.4",
+  "version": "0.1.8",
   "description": "A minimal Electron fillr application",
   "main": "main.js",
   "scripts": {
@@ -18,20 +18,20 @@
   "author": "Fillr",
   "license": "Copyright Pop Tech",
   "devDependencies": {
-    "electron": "^5.0.4",
-    "electron-builder": "^20.40.2"
+    "electron": "^5.0.11",
+    "electron-builder": "^20.44.4"
   },
   "dependencies": {
-    "@fillr_letspop/desktop-autofill": "^0.1.4",
-    "@fillr_letspop/cart-scraper": "^1.3.42"
+    "@fillr_letspop/cart-scraper": "^1.3.42",
+    "@fillr_letspop/desktop-autofill": "^0.1.8"
   },
   "build": {
-    "productName": "Fillr Electron",
+    "productName": "Fillr-Electron",
     "appId": "com.fillr.electron",
     "asar": true,
     "mac": {
       "target": [
-        "default"
+        "pkg"
       ],
       "icon": "./resources/icon.png"
     },
@@ -41,7 +41,6 @@
     },
     "win": {
       "target": [
-        "zip",
         "nsis"
       ],
       "icon": "./resources/icon.png"

--- a/index.ts
+++ b/index.ts
@@ -9,20 +9,33 @@ import * as FillrScraper from '@fillr_letspop/cart-scraper';
 //   "PersonalDetails.LastName": "Wick",
 // }
 
-const devKey = '';  // Set your dev key
-const secretKey = ''; // Set your secret key
-const profileDataHandler = new ProfileDataInterface((mappings) => {
-  mappings.profile = profileData; // Set your profile data
-  fillr.performFill(mappings);
-  console.log(fillr.getApiState().toString()) // Check api state
-})
+let intervalCount = 0;
 
-const fillr = new FillrController(devKey, secretKey, profileDataHandler);
+// Waiting for document readystate to be complete...
+const interval = setInterval(() => {
+  intervalCount++;
+  if (document && document.readyState === "complete" || intervalCount == 10) {
+    clearInterval(interval);
 
-FillrScraper.setDevKey(devKey);
-const onCartDetected = function(ev) {
-  // const cartInfo = ev.detail;
-  // Do something with cartInfo. See the example cart information json on readme
-}
-document.addEventListener('fillr:cart:detected', onCartDetected);
-FillrScraper.start();
+    const devKey = '';  // Set your dev key
+    const secretKey = ''; // Set your secret key
+
+    // Autofill setup
+    const profileDataHandler = new ProfileDataInterface((mappings) => {
+      mappings.profile = profileData; // Set your profile data
+      fillr.performFill(mappings);
+      console.log(fillr.getApiState().toString()) // Check api state
+    })
+
+    const fillr = new FillrController(devKey, secretKey, profileDataHandler);
+
+    // Cart scraper setup
+    FillrScraper.setDevKey(devKey);
+    const onCartDetected = function(ev) {
+      // const cartInfo = ev.detail;
+      // Do something with cartInfo. See the example cart information json on readme
+    }
+    document.addEventListener('fillr:cart:detected', onCartDetected);
+    FillrScraper.start();
+  }
+}, 1000);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-sample-integration",
-  "version": "0.1.4",
+  "version": "0.1.8",
   "description": "A minimal working sample integration for Browser",
   "main": "index",
   "tpyes": "index",
@@ -15,11 +15,11 @@
   "license": "Copyright Pop Tech",
   "dependencies": {
     "@fillr_letspop/cart-scraper": "^1.3.42",
-    "@fillr_letspop/desktop-autofill": "^0.1.4"
+    "@fillr_letspop/desktop-autofill": "^0.1.8"
   },
   "devDependencies": {
     "ts-loader": "^2.3.7",
-    "tslint": "^5.18.0",
+    "tslint": "^5.20.0",
     "tslint-loader": "^3.6.0",
     "typescript": "^2.9.2",
     "typings": "^2.1.1",

--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ The `cart_total` value type of cart information represents as the number to avoi
 
 See the sample extension under `dist/chrome` after running build script. You can check the basic functionality of `fillr-extension` library on sample extension. After `load upacked`, all the page which has the form will be filled automatically.
 
-When you make your own extension, you should configure the following things on `manifest.json`. `all_frames` should be `true` and `js` includes the files which imports `@fillr_letspop/desktop-autofill`. This will enable all the iframe which has form to be filled.
+When you make your own extension, you should configure the following things on `manifest.json`. `all_frames` should be `true` and `js` includes the files which imports `@fillr_letspop/desktop-autofill`. This will enable all the iframe which has form to be filled. Also, `match_about_blank` should be `true` to inject the script in iframe having no url.
 
 ```
   "content_scripts": [
@@ -110,6 +110,7 @@ When you make your own extension, you should configure the following things on `
         "https://*/*"
       ],
       "all_frames": true,
+      "match_about_blank": true,
       "js": [
         "sample-index-bundled.js"
       ]

--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,11 @@ The `cart_total` value type of cart information represents as the number to avoi
 
 See the sample extension under `dist/chrome` after running build script. You can check the basic functionality of `fillr-extension` library on sample extension. After `load upacked`, all the page which has the form will be filled automatically.
 
-When you make your own extension, you should configure the following things on `manifest.json`. `all_frames` should be `true` and `js` includes the files which imports `@fillr_letspop/desktop-autofill`. This will enable all the iframe which has form to be filled. Also, `match_about_blank` should be `true` to inject the script in iframe having no url.
+When you make your own extension, you should configure the following things in your `manifest.json`. This configuration will enable all the iframe which has form to be filled. 
+
+- `all_frames` should be `true`.
+- `js` should include the files which imports `@fillr_letspop/desktop-autofill`. 
+- `match_about_blank` should be `true` to inject the script in iframe having no url.
 
 ```
   "content_scripts": [


### PR DESCRIPTION
## Overview

This PR fixes autofill issues on Honey's top 43 sites and updates package, readme and license. 
- add interval and check ready state
- add the configuration for `match_about_blank` to be true on manifest.json
- update package version
- update readme

## Card
https://trello.com/c/bb0n21AJ

## Related PR
https://github.com/Fillr/fillr-stack/pull/1645

## Version Bump
0.1.8